### PR TITLE
Convert drawable to bitmap to avoid ClassCastException

### DIFF
--- a/CircularImageView/src/com/mikhaellopez/circularimageview/CircularImageView.java
+++ b/CircularImageView/src/com/mikhaellopez/circularimageview/CircularImageView.java
@@ -67,73 +67,86 @@ public class CircularImageView extends ImageView {
 	}
 
 	@Override
-	public void onDraw(Canvas canvas) {
-		// load the bitmap
-		BitmapDrawable bitmapDrawable = (BitmapDrawable) this.getDrawable();
-		if (bitmapDrawable != null)
-			image = bitmapDrawable.getBitmap();
+    public void onDraw(Canvas canvas) {
+        image = drawableToBitmap(getDrawable());
 
-		// init shader
-		if (image != null) {
+        // init shader
+        if (image != null) {
 
-			canvasSize = canvas.getWidth();
-			if(canvas.getHeight()<canvasSize)
-				canvasSize = canvas.getHeight();
+            canvasSize = canvas.getWidth();
+            if (canvas.getHeight() < canvasSize)
+                canvasSize = canvas.getHeight();
 
-			BitmapShader shader = new BitmapShader(Bitmap.createScaledBitmap(image, canvasSize, canvasSize, false), Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
-			paint.setShader(shader);
+            BitmapShader shader = new BitmapShader(Bitmap.createScaledBitmap(image, canvasSize, canvasSize, false), Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
+            paint.setShader(shader);
 
-			// circleCenter is the x or y of the view's center
-			// radius is the radius in pixels of the cirle to be drawn
-			// paint contains the shader that will texture the shape
-			int circleCenter = (canvasSize - (borderWidth * 2)) / 2;
-			canvas.drawCircle(circleCenter + borderWidth, circleCenter + borderWidth, ((canvasSize - (borderWidth * 2)) / 2) + borderWidth - 4.0f, paintBorder);
-			canvas.drawCircle(circleCenter + borderWidth, circleCenter + borderWidth, ((canvasSize - (borderWidth * 2)) / 2) - 4.0f, paint);
-		}
-	}
+            // circleCenter is the x or y of the view's center
+            // radius is the radius in pixels of the cirle to be drawn
+            // paint contains the shader that will texture the shape
+            int circleCenter = (canvasSize - (borderWidth * 2)) / 2;
+            canvas.drawCircle(circleCenter + borderWidth, circleCenter + borderWidth, ((canvasSize - (borderWidth * 2)) / 2) + borderWidth - 4.0f, paintBorder);
+            canvas.drawCircle(circleCenter + borderWidth, circleCenter + borderWidth, ((canvasSize - (borderWidth * 2)) / 2) - 4.0f, paint);
+        }
+    }
 
-	@Override
-	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		int width = measureWidth(widthMeasureSpec);
-		int height = measureHeight(heightMeasureSpec);
-		setMeasuredDimension(width, height);
-	}
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = measureWidth(widthMeasureSpec);
+        int height = measureHeight(heightMeasureSpec);
+        setMeasuredDimension(width, height);
+    }
 
-	private int measureWidth(int measureSpec) {
-		int result = 0;
-		int specMode = MeasureSpec.getMode(measureSpec);
-		int specSize = MeasureSpec.getSize(measureSpec);
+    private int measureWidth(int measureSpec) {
+        int result = 0;
+        int specMode = MeasureSpec.getMode(measureSpec);
+        int specSize = MeasureSpec.getSize(measureSpec);
 
-		if (specMode == MeasureSpec.EXACTLY) {
-			// The parent has determined an exact size for the child.
-			result = specSize;
-		} else if (specMode == MeasureSpec.AT_MOST) {
-			// The child can be as large as it wants up to the specified size.
-			result = specSize;
-		} else {
-			// The parent has not imposed any constraint on the child.
-			result = canvasSize;
-		}
+        if (specMode == MeasureSpec.EXACTLY) {
+            // The parent has determined an exact size for the child.
+            result = specSize;
+        } else if (specMode == MeasureSpec.AT_MOST) {
+            // The child can be as large as it wants up to the specified size.
+            result = specSize;
+        } else {
+            // The parent has not imposed any constraint on the child.
+            result = canvasSize;
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	private int measureHeight(int measureSpecHeight) {
-		int result = 0;
-		int specMode = MeasureSpec.getMode(measureSpecHeight);
-		int specSize = MeasureSpec.getSize(measureSpecHeight);
+    private int measureHeight(int measureSpecHeight) {
+        int result = 0;
+        int specMode = MeasureSpec.getMode(measureSpecHeight);
+        int specSize = MeasureSpec.getSize(measureSpecHeight);
 
-		if (specMode == MeasureSpec.EXACTLY) {
-			// We were told how big to be
-			result = specSize;
-		} else if (specMode == MeasureSpec.AT_MOST) {
-			// The child can be as large as it wants up to the specified size.
-			result = specSize;
-		} else {
-			// Measure the text (beware: ascent is a negative number)
-			result = canvasSize;
-		}
+        if (specMode == MeasureSpec.EXACTLY) {
+            // We were told how big to be
+            result = specSize;
+        } else if (specMode == MeasureSpec.AT_MOST) {
+            // The child can be as large as it wants up to the specified size.
+            result = specSize;
+        } else {
+            // Measure the text (beware: ascent is a negative number)
+            result = canvasSize;
+        }
 
-		return (result + 2);
-	}
+        return (result + 2);
+    }
+
+    public Bitmap drawableToBitmap(Drawable drawable) {
+        if (drawable == null) {
+            return null;
+        } else if (drawable instanceof BitmapDrawable) {
+            return ((BitmapDrawable) drawable).getBitmap();
+        }
+
+        Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+
+        return bitmap;
+    }
 }


### PR DESCRIPTION
In some cases (when using Picasso for loading images) we don't have BitmapDrawable, so it
causes an exception.
