### PR TITLE
Changed attribute names to be less generic to avoid conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
     }
 }
 

--- a/circularimageview/build.gradle
+++ b/circularimageview/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
+    }
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'

--- a/circularimageview/src/main/java/com/mikhaellopez/circularimageview/CircularImageView.java
+++ b/circularimageview/src/main/java/com/mikhaellopez/circularimageview/CircularImageView.java
@@ -61,16 +61,16 @@ public class CircularImageView extends ImageView {
         TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.CircularImageView, defStyleAttr, 0);
 
         // Init Border
-        if (attributes.getBoolean(R.styleable.CircularImageView_civ_border, true)) {
+        if (attributes.getBoolean(R.styleable.CircularImageView_lciv_border, true)) {
             float defaultBorderSize = DEFAULT_BORDER_WIDTH * getContext().getResources().getDisplayMetrics().density;
-            setBorderWidth(attributes.getDimension(R.styleable.CircularImageView_civ_border_width, defaultBorderSize));
-            setBorderColor(attributes.getColor(R.styleable.CircularImageView_civ_border_color, Color.WHITE));
+            setBorderWidth(attributes.getDimension(R.styleable.CircularImageView_lciv_border_width, defaultBorderSize));
+            setBorderColor(attributes.getColor(R.styleable.CircularImageView_lciv_border_color, Color.WHITE));
         }
 
         // Init Shadow
-        if (attributes.getBoolean(R.styleable.CircularImageView_civ_shadow, false)) {
+        if (attributes.getBoolean(R.styleable.CircularImageView_lciv_shadow, false)) {
             shadowRadius = DEFAULT_SHADOW_RADIUS;
-            drawShadow(attributes.getFloat(R.styleable.CircularImageView_civ_shadow_radius, shadowRadius), attributes.getColor(R.styleable.CircularImageView_civ_shadow_color, shadowColor));
+            drawShadow(attributes.getFloat(R.styleable.CircularImageView_lciv_shadow_radius, shadowRadius), attributes.getColor(R.styleable.CircularImageView_lciv_shadow_color, shadowColor));
         }
     }
     //endregion

--- a/circularimageview/src/main/res/values/attrs.xml
+++ b/circularimageview/src/main/res/values/attrs.xml
@@ -2,12 +2,12 @@
 <resources>
 
     <declare-styleable name="CircularImageView">
-        <attr name="civ_border" format="boolean"/>
-        <attr name="civ_border_width" format="dimension"/>
-        <attr name="civ_border_color" format="color"/>
-        <attr name="civ_shadow" format="boolean"/>
-        <attr name="civ_shadow_color" format="color"/>
-        <attr name="civ_shadow_radius" format="float"/>
+        <attr name="lciv_border" format="boolean"/>
+        <attr name="lciv_border_width" format="dimension"/>
+        <attr name="lciv_border_color" format="color"/>
+        <attr name="lciv_shadow" format="boolean"/>
+        <attr name="lciv_shadow_color" format="color"/>
+        <attr name="lciv_shadow_radius" format="float"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Changed attribute names to less generic versions to avoid naming conflicts with other libraries such as Instabug. 
Moved library dependant classpaths to the library