### PR TITLE
Remove android:supportsRtl="true" from AndroidManifest.xml

### DIFF
--- a/circularimageview/src/main/AndroidManifest.xml
+++ b/circularimageview/src/main/AndroidManifest.xml
@@ -3,6 +3,6 @@
 
     <application
         android:allowBackup="true"
-        android:supportsRtl="true" />
+        />
 
 </manifest>


### PR DESCRIPTION
When setting android:supportsRtl="true" in the Manifest,
this value is set as true also at the hosting App uses that value, which is false by default, as shown in the [Docs](https://developer.android.com/guide/topics/manifest/application-element.html).
To prevent that we have to set in the Application tag 
    <application
        tools:replace="android:supportsRtl"
        android:supportsRtl="false">
