### PR TITLE
No Border == 0 border width

### DIFF
--- a/circularimageview/src/main/java/com/mikhaellopez/circularimageview/CircularImageView.java
+++ b/circularimageview/src/main/java/com/mikhaellopez/circularimageview/CircularImageView.java
@@ -67,6 +67,8 @@ public class CircularImageView extends ImageView {
             float defaultBorderSize = DEFAULT_BORDER_WIDTH * getContext().getResources().getDisplayMetrics().density;
             setBorderWidth(attributes.getDimension(R.styleable.CircularImageView_civ_border_width, defaultBorderSize));
             setBorderColor(attributes.getColor(R.styleable.CircularImageView_civ_border_color, Color.WHITE));
+        } else {
+            setBorderWidth(0);
         }
 
         // Init Shadow


### PR DESCRIPTION
If you disable border it should not draw a border at all and not take a border into account for drawing the circle. Therefore set it to 0 when disabled.